### PR TITLE
Initial support for H5P assets

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -1106,6 +1106,21 @@ OutputPlugin.prototype.writeCourseAssets = function (
                                   );
                                 });
                                 ars.on('end', function () {
+                                  if (
+                                    asset.mimeType ===
+                                    'application/octet-stream'
+                                  ) {
+                                    if (
+                                      outputFilename
+                                        .toLowerCase()
+                                        .match(/.h5p$/i)
+                                    ) {
+                                      return storage.unzipH5PAsset(
+                                        outputFilename,
+                                        callback
+                                      );
+                                    }
+                                  }
                                   return callback();
                                 });
                                 ars.pipe(aws);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "adm-zip": "^0.5.9",
     "archiver": "^3.1.1",
     "async": "^3.1.0",
     "bcrypt-nodejs": "0.0.3",

--- a/plugins/output/adapt/importsource.js
+++ b/plugins/output/adapt/importsource.js
@@ -230,10 +230,18 @@ function ImportSource(req, done) {
               var assetJson = assetsJson[assetName];
               var tags = [];
 
+              let fileType = mime.getType(assetName);
+              if (!fileType) {
+                //Handling H5P fileType null/undefined
+                if (assetExt.toLowerCase() === '.h5p') {
+                  fileType = 'application/octet-stream';
+                }
+              }
+
               var fileMeta = {
                 oldId: assetId,
                 title: assetTitle,
-                type: mime.getType(assetName),
+                type: fileType,
                 size: fileStat['size'],
                 filename: assetName,
                 description: assetDescription,


### PR DESCRIPTION
https://h5p.org/

Example H5P assets can be found here https://h5p.org/content-types-and-applications 

- Checks file mime type on import, sets to "application/octet-stream" for H5P assets
- Unzips H5P asset on course preview/publish
- Cleans up unzipped H5P asset for course export
