### PR TITLE
Include scriptSafe and pluginsIncluded in config.json on publish

### DIFF
--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -205,6 +205,21 @@ function publishCourse(courseId, mode, request, response, next) {
         );
       },
       function (callback) {
+        logger.log(
+          'info',
+          'Adding scriptSafe plugins from config: ' +
+            configuration.conf.scriptSafe
+        );
+        outputJson.config.build = outputJson.config.build
+          ? outputJson.config.build
+          : {};
+        outputJson.config.build.scriptSafe = configuration.conf.scriptSafe;
+
+        // build section of config.json gets deleted, we need this info for adapt-cdn-config to generate version info for plugins used in the course
+        outputJson.config.pluginsIncluded = outputJson.config.build.includes;
+        callback(null);
+      },
+      function (callback) {
         self.writeCourseJSON(
           outputJson,
           path.join(BUILD_FOLDER, Constants.Folders.Course),

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -210,9 +210,7 @@ function publishCourse(courseId, mode, request, response, next) {
           'Adding scriptSafe plugins from config: ' +
             configuration.conf.scriptSafe
         );
-        outputJson.config.build = outputJson.config.build
-          ? outputJson.config.build
-          : {};
+        outputJson.config.build =  outputJson?.config?.build || {};
         outputJson.config.build.scriptSafe = configuration.conf.scriptSafe;
 
         // build section of config.json gets deleted, we need this info for adapt-cdn-config to generate version info for plugins used in the course


### PR DESCRIPTION
- scriptSafe needed when exporting courses, to allow post build scripts to run
- pluginsIncluded is currently used to output information on which plugins are used in the course (temporary, as this can be accessed in Adapt.build instead)