### PR TITLE
Only checking file extension for H5P assets

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -1107,19 +1107,12 @@ OutputPlugin.prototype.writeCourseAssets = function (
                                 });
                                 ars.on('end', function () {
                                   if (
-                                    asset.mimeType ===
-                                    'application/octet-stream'
+                                    outputFilename.toLowerCase().match(/.h5p$/i)
                                   ) {
-                                    if (
-                                      outputFilename
-                                        .toLowerCase()
-                                        .match(/.h5p$/i)
-                                    ) {
-                                      return storage.unzipH5PAsset(
-                                        outputFilename,
-                                        callback
-                                      );
-                                    }
+                                    return storage.unzipH5PAsset(
+                                      outputFilename,
+                                      callback
+                                    );
                                   }
                                   return callback();
                                 });

--- a/plugins/filestorage/localfs/index.js
+++ b/plugins/filestorage/localfs/index.js
@@ -275,10 +275,8 @@ LocalFileStorage.prototype.processFileUpload = function (
         },
         // Handle unzipping of .h5p assets
         function (nextFunc) {
-          if (data.mimeType === 'application/octet-stream') {
-            if (data.path.toLowerCase().match(/.h5p$/i)) {
-              return self.unzipH5PAsset(newPath, nextFunc);
-            }
+          if (data.path.toLowerCase().match(/.h5p$/i)) {
+            return self.unzipH5PAsset(newPath, nextFunc);
           }
 
           return nextFunc();


### PR DESCRIPTION
- Some H5P assets were set with a different mime type, so we no longer assume type, only file extension.