### PR TITLE
Store unzipped H5P assets in public/assets folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /conf/migrate.json
 /data
 
+/public/assets
 /frontend/build
 
 /frontend/src/modules/modules.js

--- a/lib/application.js
+++ b/lib/application.js
@@ -314,6 +314,7 @@ Origin.prototype.createServer = function (options, cb) {
         )
       )
     );
+    server.use(express.static('public'));
     if (!app.configuration.getConfig('isProduction')) {
       server.use(
         express.static(

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -991,6 +991,7 @@ OutputPlugin.prototype.writeCourseAssets = function (
   jsonDestinationFolder,
   destinationFolder,
   jsonObject,
+  mode,
   next
 ) {
   fs.remove(destinationFolder, function (err) {
@@ -1080,46 +1081,62 @@ OutputPlugin.prototype.writeCourseAssets = function (
                             return callback(err);
                           }
 
-                          return (
-                            storage &&
-                            storage.createReadStream(
-                              asset.path,
-                              function (ars) {
-                                var aws = fs.createWriteStream(outputFilename);
-                                ars.on('error', function (err) {
-                                  logger.log(
-                                    'error',
-                                    'Error copying ' +
-                                      asset.path +
-                                      ' to ' +
-                                      outputFilename +
-                                      ': ' +
-                                      err.message
-                                  );
-                                  return callback(
-                                    'Error copying ' +
-                                      asset.path +
-                                      ' to ' +
-                                      outputFilename +
-                                      ': ' +
-                                      err.message
-                                  );
-                                });
-                                ars.on('end', function () {
-                                  if (
-                                    outputFilename.toLowerCase().match(/.h5p$/i)
-                                  ) {
-                                    return storage.unzipH5PAsset(
-                                      outputFilename,
-                                      callback
+                          if (!storage) {
+                            logger.log(
+                              'error',
+                              'Error getting storage plugin.'
+                            );
+                            return callback(err);
+                          }
+
+                          // ---- Handle H5P assets ----
+                          const assetPathSrc = storage.resolvePath(asset.path);
+                          if (assetPathSrc.match(/\.h5p$/)) {
+                            // check asset exists unzipped in public/assets/
+                            const h5pFolder =
+                              storage.checkH5PAssetExistsUnzipped(assetPathSrc);
+
+                            // PREVIEW - do nothing, H5P assets will be served statically from public/assets/
+                            if (mode === Constants.Modes.Preview) {
+                              return callback();
+                            }
+
+                            // PUBLISH - copy H5P folder to course build
+                            if (mode === Constants.Modes.Publish) {
+                              fs.copy(
+                                h5pFolder,
+                                outputFilename.replace(/\.h5p$/, ''),
+                                (err) => {
+                                  if (err) {
+                                    logger.log(
+                                      'error',
+                                      `Error copying file ${assetPathSrc}`
                                     );
+                                    return callback(err);
                                   }
                                   return callback();
-                                });
-                                ars.pipe(aws);
+                                }
+                              );
+                            }
+
+                            // EXPORT - zip up H5P folder in public/assets and copy to course build
+                            if (mode === Constants.Modes.Export) {
+                              storage.zipH5PAsset(h5pFolder, outputFilename);
+                              return callback();
+                            }
+                          } else {
+                            // All other assets get copied to build folder
+                            fs.copy(assetPathSrc, outputFilename, (err) => {
+                              if (err) {
+                                logger.log(
+                                  'error',
+                                  `Error copying file ${assetPathSrc}`
+                                );
+                                return callback(err);
                               }
-                            )
-                          );
+                              return callback();
+                            });
+                          }
                         }
                       );
                     },

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -195,38 +195,13 @@ function publishCourse(courseId, mode, request, response, next) {
           assetsJsonFolder,
           assetsFolder,
           outputJson,
+          mode,
           function (err, modifiedJson) {
             if (err) {
               return callback(err);
             }
             // Store the JSON with the new paths to assets
             outputJson = modifiedJson;
-
-            // Clean up H5P assets
-
-            glob(`${assetsFolder}/*.h5p`, function (error, h5pAssets) {
-              if (error) {
-                return callback(error);
-              }
-              try {
-                h5pAssets.forEach((h5pAsset) => {
-                  const h5pFolder = path.basename(h5pAsset, '.h5p');
-                  // remove unzipped H5P asset
-                  if (mode === Constants.Modes.Export) {
-                    fs.removeSync(path.join(assetsFolder, h5pFolder));
-                  }
-                  // remove zipped H5P asset
-                  if (
-                    mode === Constants.Modes.Publish ||
-                    mode === Constants.Modes.Preview
-                  ) {
-                    fs.removeSync(h5pAsset);
-                  }
-                });
-              } catch (error) {
-                return callback(error);
-              }
-            });
 
             callback(null);
           }
@@ -238,7 +213,7 @@ function publishCourse(courseId, mode, request, response, next) {
           'Adding scriptSafe plugins from config: ' +
             configuration.conf.scriptSafe
         );
-        outputJson.config.build =  outputJson?.config?.build || {};
+        outputJson.config.build = outputJson?.config?.build || {};
         outputJson.config.build.scriptSafe = configuration.conf.scriptSafe;
 
         // build section of config.json gets deleted, we need this info for adapt-cdn-config to generate version info for plugins used in the course


### PR DESCRIPTION
## Proposed changes

- Including new parameter "mode" to writeCourseAssets, which allows us to handle H5P assets depending on if the build is a prevew/publish/export
- when courses are previewed, H5P assets can be served statically from the new public/assets folder
