### PR TITLE
Allow radio form fields to conditionally display other form fields

### DIFF
--- a/frontend/src/modules/editor/global/views/editorOriginView.js
+++ b/frontend/src/modules/editor/global/views/editorOriginView.js
@@ -47,6 +47,7 @@ define(function (require) {
       this.$('.form-container').append(this.form.el);
       // Set the delays going to stop jumping pages
       _.delay(_.bind(this.setViewToReady, this, 400));
+      this.refreshConditionalViews();
     },
 
     filterForm: function (filter) {
@@ -261,6 +262,25 @@ define(function (require) {
       Origin.Notify.alert({ type: 'error', title: title, text: text });
 
       Origin.trigger('sidebar:resetButtons');
+    },
+
+    refreshConditionalViews: function () {
+      if (!this.form) return;
+
+      // Setup initial view for conditional fields
+      const conditionalRadios = this.$('[data-is-conditional]');
+      conditionalRadios.each((index, radio) => {
+        const $radio = $(radio);
+        const nameOfRadio = $radio.attr('name');
+        const valueOfRadio = this.$(`input[name=${nameOfRadio}]:checked`).val();
+        const dependencies = this.$(`[data-depends-on=${nameOfRadio}]`);
+
+        dependencies.each((index, field) => {
+          const $field = $(field);
+          const matchOption = $field.attr('data-option-match');
+          $(field).toggle(valueOfRadio === matchOption);
+        });
+      });
     },
   });
 

--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -4,6 +4,7 @@ define(['core/origin', 'backbone-forms'], function (Origin, BackboneForms) {
   var templateData = Backbone.Form.Field.prototype.templateData;
   var initialize = Backbone.Form.editors.Base.prototype.initialize;
   var textInitialize = Backbone.Form.editors.Text.prototype.initialize;
+  var radioInitialize = Backbone.Form.editors.Radio.prototype.initialize;
   var textAreaRender = Backbone.Form.editors.TextArea.prototype.render;
   var textAreaSetValue = Backbone.Form.editors.TextArea.prototype.setValue;
 
@@ -271,6 +272,27 @@ define(['core/origin', 'backbone-forms'], function (Origin, BackboneForms) {
       delayedDetermineChange();
     } else {
       event.preventDefault();
+    }
+  };
+
+  // add listener to is-conditional-radio inputs
+  Backbone.Form.editors.Radio.prototype.initialize = function (options) {
+    radioInitialize.call(this, options);
+
+    const attrs = options.schema.editorAttrs;
+    if (!attrs) return;
+
+    if (attrs['data-is-conditional']) {
+      console.log('Radio input is conditional, setting up event listeners...');
+      console.log(options);
+
+      options.form.on(`${options.key}:change`, function (form, $editor) {
+        const currentOption = $editor.getValue();
+        $(`[data-depends-on=${options.key}]`).toggle(false);
+        $(
+          `[data-depends-on=${options.key}][data-option-match=${currentOption}]`
+        ).toggle(true);
+      });
     }
   };
 });


### PR DESCRIPTION
When adding an attribute to a "Radio" input type in a content/plugin schema "data-is-conditional"
```
    "type-radio": {
      "type": "string",
      "required": false,
      "default": "option-1",
      "inputType": {
        "type": "Radio",
        "options": [
          { "val": "option-1", "label": "Option 1" },
          { "val": "option-2", "label": "Option 2" },
          { "val": "option-3", "label": "Option 3" }
        ]
      },
      "editorAttrs": { "data-is-conditional": "true" },
      "validators": [],
      "title": "Radio field to show conditional views"
    },
```

You can add the fieldAttrs to other properties you wish to hide/show
```
    "option-1": {
      "type": "string",
      "required": false,
      "default": "Option 1",
      "inputType": "Text",
      "validators": [],
      "title": "Option 1",
      "fieldAttrs": {
        "data-depends-on": "type-radio",
        "data-option-match": "option-1"
      }
    },
    "option-2": {
      "type": "string",
      "required": false,
      "default": "Option 2",
      "inputType": "Text",
      "validators": [],
      "title": "Option 2",
      "fieldAttrs": {
        "data-depends-on": "type-radio",
        "data-option-match": "option-2"
      }
    },
    "option-3": {
      "type": "string",
      "required": false,
      "default": "Option 3",
      "inputType": "Text",
      "validators": [],
      "title": "Option 3",
      "fieldAttrs": {
        "data-depends-on": "type-radio",
        "data-option-match": "option-3"
      }
    }
```

where the value of "data-depends-on" is the name of the Radio input field and the value of "data-option-match" is the value of the option if toggled, should show this field.