### PR TITLE
Allow Asset Management to serve svgs, as they don't have a thumbnail

### DIFF
--- a/frontend/src/modules/assetManagement/templates/assetManagementListItem.hbs
+++ b/frontend/src/modules/assetManagement/templates/assetManagementListItem.hbs
@@ -28,7 +28,7 @@
 
     {{#ifValueEquals assetType "image"}}
         {{#if metadata}}
-        <div class="asset-management-list-item-image" data-style="background-image:url(api/asset/thumb/{{_id}})">
+        <div class="asset-management-list-item-image" data-style="background-image:url(api/asset/{{#ifValueEquals fileExtension "svg"}}serve{{else}}thumb{{/ifValueEquals}}/{{_id}})">
         {{else}}
         <div class="asset-management-list-item-image">
             <i class="fa fa-file-image-o"></i>
@@ -39,7 +39,7 @@
 
     {{#ifValueEquals assetType "video"}}
         {{#if metadata}}
-        <div class="asset-management-list-item-image" data-style="background-image:url(api/asset/thumb/{{_id}})"}>
+        <div class="asset-management-list-item-image" data-style="background-image:url(api/asset/thumb/{{_id}})">
         {{else}}
         <div class="asset-management-list-item-image">
             <i class="fa fa-file-video-o"></i>

--- a/frontend/src/modules/assetManagement/views/assetManagementItemView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementItemView.js
@@ -27,6 +27,8 @@ define(function (require) {
         this.listenTo(this, 'remove', this.remove);
         this.listenTo(this.model, 'destroy', this.remove);
         this.listenTo(this.model, 'change:_isDeleted', this.onReRender);
+        const filename = this.model.get('filename');
+        this.model.set('fileExtension', filename.split('.').pop());
       },
 
       onReRender: function () {


### PR DESCRIPTION
## Proposed changes

SVG images in the Assest Management view were not shown as they don't have a thumbnail to access like the other image types.
Now added fileExtension model attribute to Assest Management view, so we can choose to serve svg images specifically.


