### PR TITLE
Add support for List type in Theme Picker

### DIFF
--- a/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
+++ b/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
@@ -258,7 +258,9 @@ define(function (require) {
           fieldView.setValue(value);
           fieldView.render();
           $('div[data-editor-id*="' + key + '"]').append(fieldView.editor.$el);
-        } else {
+        } else if(inputType === "List"){
+          fieldView.setValue(value);
+        }else {
           fieldView.editor.$el.val(value.toString());
         }
       },


### PR DESCRIPTION
## Proposed changes

If using a List type in the theme's variables schema, these values were not getting restored when revisting the Theme Picker view.
List type now handled.
