### PR TITLE
Allow Select form fields to conditionally display other form fields

### DIFF
--- a/frontend/src/modules/editor/global/views/editorOriginView.js
+++ b/frontend/src/modules/editor/global/views/editorOriginView.js
@@ -268,19 +268,31 @@ define(function (require) {
     refreshConditionalViews: function () {
       if (!this.form) return;
 
-      // Setup initial view for conditional fields
-      const conditionalRadios = $('[data-is-conditional]');
-      conditionalRadios.each((index, radio) => {
-        const $radio = $(radio);
-        const nameOfRadio = $radio.attr('name');
-        const valueOfRadio = $(`input[name=${nameOfRadio}]:checked`).val();
-        const dependencies = $(`[data-depends-on=${nameOfRadio}]`);
-
-        dependencies.each((index, field) => {
-          const $field = $(field);
-          const matchOption = $field.attr('data-option-match');
-          $(field).toggle(valueOfRadio === matchOption);
-        });
+      $('[data-is-conditional]').each(function(index, element){
+        const $element = $(element);
+        const tagName = $element.prop('tagName').toLowerCase();
+        
+        if (tagName === 'select') {
+          const nameOfSelect = $element.attr('name');
+          const valueOfSelect = $element.val().toLowerCase();
+          const dependencies = $(`[data-depends-on=${nameOfSelect}]`);
+          
+          dependencies.each((index, field) => {
+            const $field = $(field);
+            const matchOption = $field.attr('data-option-match');
+            $field.toggle(valueOfSelect === matchOption);
+          });
+        } else {
+          const nameOfRadio = $element.attr('name');
+          const valueOfRadio = $(`input[name=${nameOfRadio}]:checked`).val();
+          const dependencies = $(`[data-depends-on=${nameOfRadio}]`);
+          
+          dependencies.each((index, field) => {
+            const $field = $(field);
+            const matchOption = $field.attr('data-option-match');
+            $field.toggle(valueOfRadio === matchOption);
+          });
+        }
       });
     },
   });

--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -5,6 +5,7 @@ define(['core/origin', 'backbone-forms'], function (Origin, BackboneForms) {
   var initialize = Backbone.Form.editors.Base.prototype.initialize;
   var textInitialize = Backbone.Form.editors.Text.prototype.initialize;
   var radioInitialize = Backbone.Form.editors.Radio.prototype.initialize;
+  var selectInitialize = Backbone.Form.editors.Select.prototype.initialize;
   var textAreaRender = Backbone.Form.editors.TextArea.prototype.render;
   var textAreaSetValue = Backbone.Form.editors.TextArea.prototype.setValue;
 
@@ -276,9 +277,12 @@ define(['core/origin', 'backbone-forms'], function (Origin, BackboneForms) {
   };
 
   // add listener to is-conditional-radio inputs
-  Backbone.Form.editors.Radio.prototype.initialize = function (options) {
-    radioInitialize.call(this, options);
+  Backbone.Form.editors.Radio.prototype.initialize = initializeEditor;
+  Backbone.Form.editors.Select.prototype.initialize = initializeEditor;
 
+   function initializeEditor(options) {
+    radioInitialize.call(this, options);
+    selectInitialize.call(this, options);
     const attrs = options.schema.editorAttrs;
     if (!attrs) return;
 
@@ -291,5 +295,5 @@ define(['core/origin', 'backbone-forms'], function (Origin, BackboneForms) {
         ).toggle(true);
       });
     }
-  };
+   }
 });


### PR DESCRIPTION
When adding an attribute to a "Select" input type in a content/plugin schema "data-is-conditional"

    "type-Select": {
      "type": "string",
      "required": false,
      "default": "option-1",
      "inputType": {
        "type": "Select",
        "options": [
          { "val": "option-1", "label": "Option 1" },
          { "val": "option-2", "label": "Option 2" },
          { "val": "option-3", "label": "Option 3" }
        ]
      },
      "editorAttrs": { "data-is-conditional": "true" },
      "validators": [],
      "title": "Radio field to show conditional views"
    },
You can add the fieldAttrs to other properties you wish to hide/show

    "option-1": {
      "type": "string",
      "required": false,
      "default": "Option 1",
      "inputType": "Text",
      "validators": [],
      "title": "Option 1",
      "fieldAttrs": {
        "data-depends-on": "type-Select",
        "data-option-match": "option-1"
      }
    },
    "option-2": {
      "type": "string",
      "required": false,
      "default": "Option 2",
      "inputType": "Text",
      "validators": [],
      "title": "Option 2",
      "fieldAttrs": {
        "data-depends-on": "type-Select",
        "data-option-match": "option-2"
      }
    },
    "option-3": {
      "type": "string",
      "required": false,
      "default": "Option 3",
      "inputType": "Text",
      "validators": [],
      "title": "Option 3",
      "fieldAttrs": {
        "data-depends-on": "type-Select",
        "data-option-match": "option-3"
      }
    }
where the value of "data-depends-on" is the name of the Select input field and the value of "data-option-match" is the value of the option if toggled, should show this field.